### PR TITLE
fix perm to octal

### DIFF
--- a/acnlwikiscraper/main.go
+++ b/acnlwikiscraper/main.go
@@ -50,7 +50,7 @@ func main() {
 		}
 		if e.DOM.Text() == "" {
 			b, _ := e.DOM.Html()
-			ioutil.WriteFile("out.html", []byte(b), 777)
+			ioutil.WriteFile("out.html", []byte(b), 0777)
 			log.Fatal(name)
 		}
 		characterMap[name].PicQuote = e.DOM.Text()
@@ -86,5 +86,5 @@ func main() {
 	}
 
 
-	ioutil.WriteFile("results.json", b, 777)
+	ioutil.WriteFile("results.json", b, 0777)
 }


### PR DESCRIPTION
Hi.
I found you passing a perm for WriteFile method as decimal.
But you want to pass it as octal arn't you?

For example, 
`0777` is `111111111` in binary and it means `rwxrwxrwx`.
`777` is `1100001001` in binary and it means `r----x--x`.
